### PR TITLE
Added 8bits value to BitsPerPixel

### DIFF
--- a/SharpAvi/BitsPerPixel.cs
+++ b/SharpAvi/BitsPerPixel.cs
@@ -3,6 +3,8 @@
     /// <summary>Number of bits per pixel.</summary>
     public enum BitsPerPixel
     {
+        /// <summary>8 bits per pixel.</summary>
+        Bpp8 = 8,
         /// <summary>16 bits per pixel.</summary>
         Bpp16 = 16,
         /// <summary>24 bits per pixel.</summary>


### PR DESCRIPTION
Seems to be enough to get an 8bits greyscale avi. The rest of the code
take cares of the proper writing of the data.

See https://sharpavi.codeplex.com/discussions/569438
