### PR TITLE
Made the vertical flip of frames optional.

### DIFF
--- a/SharpAvi/Codecs/IVideoEncoder.cs
+++ b/SharpAvi/Codecs/IVideoEncoder.cs
@@ -23,6 +23,11 @@ namespace SharpAvi.Codecs
         int MaxEncodedSize { get; }
 
         /// <summary>
+        /// Wether the vertically flip the frame before writing
+        /// </summary>
+        bool FlipVertical { get; set; }
+
+        /// <summary>
         /// Encodes video frame.
         /// </summary>
         /// <param name="source">
@@ -72,6 +77,8 @@ namespace SharpAvi.Codecs
                     throw new NotImplementedException(); 
                 }
             }
+
+            public abstract bool FlipVertical { get; set; }
 
             public int EncodeFrame(byte[] source, int srcOffset, byte[] destination, int destOffset, out bool isKeyFrame)
             {

--- a/SharpAvi/Codecs/MotionJpegVideoEncoderWpf.cs
+++ b/SharpAvi/Codecs/MotionJpegVideoEncoderWpf.cs
@@ -32,6 +32,10 @@ namespace SharpAvi.Codecs
     {
         private readonly Int32Rect rect;
         private readonly int quality;
+        private bool flipVertical = false;
+        private byte[] sourceBuffer;
+
+
 #if FX45
         private readonly ThreadLocal<WriteableBitmap> bitmapHolder;
 #else
@@ -95,15 +99,36 @@ namespace SharpAvi.Codecs
         }
 
         /// <summary>
+        /// Wether to vertically flip the frame before writing
+        /// </summary>
+        public bool FlipVertical
+        {
+            get { return flipVertical; }
+            set { flipVertical = value; }
+        }
+
+        /// <summary>
         /// Encodes a frame.
         /// </summary>
         /// <seealso cref="IVideoEncoder.EncodeFrame"/>
         public int EncodeFrame(byte[] source, int srcOffset, byte[] destination, int destOffset, out bool isKeyFrame)
         {
+            if (flipVertical)
+            {
+                if (sourceBuffer == null)
+                {
+                    sourceBuffer = new byte[rect.Width * rect.Height * 4];
+                }
+                BitmapUtils.FlipVertical(source, srcOffset, sourceBuffer, 0, rect.Height, rect.Width * 4);
+            } else
+            {
+                sourceBuffer = source;
+            }
+
 #if FX45
             var bitmap = bitmapHolder.Value;
 #endif
-            bitmap.WritePixels(rect, source, rect.Width * 4, srcOffset);
+            bitmap.WritePixels(rect, sourceBuffer, rect.Width * 4, srcOffset);
 
             var encoderImpl = new JpegBitmapEncoder
             {

--- a/SharpAvi/Codecs/Mpeg4VideoEncoderVcm.cs
+++ b/SharpAvi/Codecs/Mpeg4VideoEncoderVcm.cs
@@ -115,7 +115,7 @@ namespace SharpAvi.Codecs
 
         private readonly int width;
         private readonly int height;
-        private readonly byte[] sourceBuffer;
+        private byte[] sourceBuffer;
         private readonly VfwApi.BitmapInfoHeader inBitmapInfo;
         private readonly VfwApi.BitmapInfoHeader outBitmapInfo;
         private readonly IntPtr compressorHandle;
@@ -129,6 +129,7 @@ namespace SharpAvi.Codecs
         private int framesFromLastKey;
         private bool isDisposed;
         private bool needEnd;
+        private bool flipVertical = true;
 
         /// <summary>
         /// Creates a new instance of <see cref="Mpeg4VideoEncoderVcm"/>.
@@ -287,6 +288,15 @@ namespace SharpAvi.Codecs
             get { return maxEncodedSize; }
         }
 
+        /// <summary>
+        /// Wether to vertically flip the frame before writing
+        /// </summary>
+        public bool FlipVertical
+        {
+            get { return flipVertical;}
+            set { flipVertical = value; }
+        }
+
         /// <summary>Encodes a frame.</summary>
         /// <seealso cref="IVideoEncoder.EncodeFrame"/>
         public int EncodeFrame(byte[] source, int srcOffset, byte[] destination, int destOffset, out bool isKeyFrame)
@@ -294,7 +304,17 @@ namespace SharpAvi.Codecs
             // TODO: Introduce Width and Height in IVideoRecorder and add Requires to EncodeFrame contract
             Contract.Assert(srcOffset + 4 * width * height <= source.Length);
 
-            BitmapUtils.FlipVertical(source, srcOffset, sourceBuffer, 0, height, width * 4);
+            if (flipVertical)
+            {
+                if (sourceBuffer == null)
+                {
+                    sourceBuffer = new byte[width * height * 4];
+                }
+                BitmapUtils.FlipVertical(source, srcOffset, sourceBuffer, 0, height, width * 4);
+            } else
+            {
+                sourceBuffer = source;
+            }
 
             var sourceHandle = GCHandle.Alloc(sourceBuffer, GCHandleType.Pinned);
             var encodedHandle = GCHandle.Alloc(destination, GCHandleType.Pinned);

--- a/SharpAvi/Codecs/SingleThreadedVideoEncoderWrapper.cs
+++ b/SharpAvi/Codecs/SingleThreadedVideoEncoderWrapper.cs
@@ -26,7 +26,7 @@ namespace SharpAvi.Codecs
         private readonly IVideoEncoder encoder;
         private readonly Thread thread;
         private readonly Dispatcher dispatcher;
-
+        
         /// <summary>
         /// Creates a new instance of <see cref="SingleThreadedVideoEncoderWrapper"/>.
         /// </summary>
@@ -101,6 +101,15 @@ namespace SharpAvi.Codecs
             {
                 return (int)dispatcher.Invoke(new Func<int>(() => encoder.MaxEncodedSize));
             }
+        }
+
+        /// <summary>
+        /// Wether to vertically flip the frame before writing
+        /// </summary>
+        public bool FlipVertical
+        {
+            get { return encoder.FlipVertical; }
+            set { encoder.FlipVertical = value; }
         }
 
         /// <summary>

--- a/SharpAvi/Codecs/UncompressedVideoEncoder.cs
+++ b/SharpAvi/Codecs/UncompressedVideoEncoder.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.Contracts;
+﻿using System;
+using System.Diagnostics.Contracts;
 
 namespace SharpAvi.Codecs
 {
@@ -13,7 +14,8 @@ namespace SharpAvi.Codecs
     {
         private readonly int width;
         private readonly int height;
-        private readonly byte[] sourceBuffer;
+        private byte[] sourceBuffer;
+        private bool flipVertical = true;
 
         /// <summary>
         /// Creates a new instance of <see cref="UncompressedVideoEncoder"/>.
@@ -55,12 +57,33 @@ namespace SharpAvi.Codecs
         }
 
         /// <summary>
+        /// Wether to vertically flip the frame before writing
+        /// </summary>
+        public bool FlipVertical
+        {
+            get { return flipVertical; }
+            set { flipVertical = value; }
+        }
+
+        /// <summary>
         /// Encodes a frame.
         /// </summary>
         /// <seealso cref="IVideoEncoder.EncodeFrame"/>
         public int EncodeFrame(byte[] source, int srcOffset, byte[] destination, int destOffset, out bool isKeyFrame)
         {
-            BitmapUtils.FlipVertical(source, srcOffset, sourceBuffer, 0, height, width * 4);
+            if (flipVertical)
+            {
+                if (sourceBuffer == null)
+                {
+                    sourceBuffer = new byte[width * height * 4];
+                }
+                BitmapUtils.FlipVertical(source, srcOffset, sourceBuffer, 0, height, width * 4);
+            }
+            else
+            {
+                sourceBuffer = source;
+            }
+
             BitmapUtils.Bgr32ToBgr24(sourceBuffer, 0, destination, destOffset, width * height);
             isKeyFrame = true;
             return MaxEncodedSize;


### PR DESCRIPTION
When writing a frame via OpenTKs
GL.ReadPixels(0, 0, width, height, PixelFormat.Bgra, PixelType.UnsignedByte, videoBuffer);

my frame seems to be already correctly oriented and sharpavi turns it upside down again. So here's a few simple getter/setter to make that part configurable.

