### PR TITLE
support write BITMAPINFOHEADER extra data

### DIFF
--- a/SharpAvi/Codecs/IVideoEncoderExtraData.cs
+++ b/SharpAvi/Codecs/IVideoEncoderExtraData.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpAvi.Codecs
+{
+    /// <summary>
+    /// Export extra data for some codecs
+    /// </summary>
+    public interface IVideoEncoderExtraData
+    {
+        /// <summary>
+        /// Encoded images header with extra data
+        /// </summary>
+        byte[] BitmapInfoHeader { get; }
+    }
+}

--- a/SharpAvi/Codecs/SingleThreadedVideoEncoderWrapper.cs
+++ b/SharpAvi/Codecs/SingleThreadedVideoEncoderWrapper.cs
@@ -14,7 +14,7 @@ namespace SharpAvi.Codecs
     /// like asynchronous encoding.
     /// </para>
     /// </remarks>
-    public class SingleThreadedVideoEncoderWrapper : IVideoEncoder, IDisposable
+    public class SingleThreadedVideoEncoderWrapper : IVideoEncoder, IVideoEncoderExtraData, IDisposable
     {
         private readonly IVideoEncoder encoder;
         private readonly SingleThreadTaskScheduler scheduler;
@@ -64,6 +64,21 @@ namespace SharpAvi.Codecs
         /// Determines the amount of space needed in the destination buffer for storing the encoded data of a single frame.
         /// </summary>
         public int MaxEncodedSize => SchedulerInvoke(() => encoder.MaxEncodedSize);
+
+        /// <summary>
+        /// Encoded images header
+        /// </summary>
+        public byte[] BitmapInfoHeader => SchedulerInvoke(() =>
+        {
+            if (encoder is IVideoEncoderExtraData extraData)
+            {
+                return extraData.BitmapInfoHeader;
+            }
+            else
+            {
+                return null;
+            }
+        });
 
         /// <summary>
         /// Encodes a video frame.

--- a/SharpAvi/Output/AviVideoStream.cs
+++ b/SharpAvi/Output/AviVideoStream.cs
@@ -13,6 +13,7 @@ namespace SharpAvi.Output
         private int height;
         private BitsPerPixel bitsPerPixel;
         private int framesWritten;
+        private byte[] bitmapInfoHeader;
 
         public AviVideoStream(int index, IAviStreamWriteHandler writeHandler, 
             int width, int height, BitsPerPixel bitsPerPixel)
@@ -68,6 +69,16 @@ namespace SharpAvi.Output
             {
                 CheckNotFrozen();
                 streamCodec = value;
+            }
+        }
+
+        public byte[] BitmapInfoHeader
+        {
+            get { return bitmapInfoHeader; }
+            set
+            {
+                CheckNotFrozen();
+                bitmapInfoHeader = value;
             }
         }
 

--- a/SharpAvi/Output/AviWriter.cs
+++ b/SharpAvi/Output/AviWriter.cs
@@ -537,39 +537,47 @@ namespace SharpAvi.Output
 
         void IAviStreamWriteHandler.WriteStreamFormat(AviVideoStream videoStream)
         {
-            // See BITMAPINFOHEADER structure
-            fileWriter.Write(40U); // size of structure
-            fileWriter.Write(videoStream.Width);
-            fileWriter.Write(videoStream.Height);
-            fileWriter.Write((short)1); // planes
-            fileWriter.Write((ushort)videoStream.BitsPerPixel); // bits per pixel
-            fileWriter.Write((uint)videoStream.Codec); // compression (codec FOURCC)
-            // 0 size is safer for uncompressed formats not to bother with stride calculation
-            var sizeInBytes = videoStream.Codec == CodecIds.Uncompressed
-                ? 0
-                : videoStream.Width * videoStream.Height * (((int)videoStream.BitsPerPixel) / 8);
-            fileWriter.Write((uint)sizeInBytes); // image size in bytes
-            fileWriter.Write(0); // X pixels per meter
-            fileWriter.Write(0); // Y pixels per meter
-
-            // Writing grayscale palette for 8-bit uncompressed stream
-            // Otherwise, no palette
-            if (videoStream.BitsPerPixel == BitsPerPixel.Bpp8 && videoStream.Codec == CodecIds.Uncompressed)
+            var bitmapInfoHeader = videoStream.BitmapInfoHeader;
+            if (bitmapInfoHeader != null)
             {
-                fileWriter.Write(256U); // palette colors used
-                fileWriter.Write(0U); // palette colors important
-                for (int i = 0; i < 256; i++)
-                {
-                    fileWriter.Write((byte)i);
-                    fileWriter.Write((byte)i);
-                    fileWriter.Write((byte)i);
-                    fileWriter.Write((byte)0);
-                }
+                fileWriter.Write(bitmapInfoHeader);
             }
             else
             {
-                fileWriter.Write(0U); // palette colors used
-                fileWriter.Write(0U); // palette colors important
+                // See BITMAPINFOHEADER structure
+                fileWriter.Write(40U); // size of structure
+                fileWriter.Write(videoStream.Width);
+                fileWriter.Write(videoStream.Height);
+                fileWriter.Write((short)1); // planes
+                fileWriter.Write((ushort)videoStream.BitsPerPixel); // bits per pixel
+                fileWriter.Write((uint)videoStream.Codec); // compression (codec FOURCC)
+                                                           // 0 size is safer for uncompressed formats not to bother with stride calculation
+                var sizeInBytes = videoStream.Codec == CodecIds.Uncompressed
+                    ? 0
+                    : videoStream.Width * videoStream.Height * (((int)videoStream.BitsPerPixel) / 8);
+                fileWriter.Write((uint)sizeInBytes); // image size in bytes
+                fileWriter.Write(0); // X pixels per meter
+                fileWriter.Write(0); // Y pixels per meter
+
+                // Writing grayscale palette for 8-bit uncompressed stream
+                // Otherwise, no palette
+                if (videoStream.BitsPerPixel == BitsPerPixel.Bpp8 && videoStream.Codec == CodecIds.Uncompressed)
+                {
+                    fileWriter.Write(256U); // palette colors used
+                    fileWriter.Write(0U); // palette colors important
+                    for (int i = 0; i < 256; i++)
+                    {
+                        fileWriter.Write((byte)i);
+                        fileWriter.Write((byte)i);
+                        fileWriter.Write((byte)i);
+                        fileWriter.Write((byte)0);
+                    }
+                }
+                else
+                {
+                    fileWriter.Write(0U); // palette colors used
+                    fileWriter.Write(0U); // palette colors important
+                }
             }
         }
 

--- a/SharpAvi/Output/EncodingVideoStreamWrapper.cs
+++ b/SharpAvi/Output/EncodingVideoStreamWrapper.cs
@@ -56,6 +56,22 @@ namespace SharpAvi.Output
             set => ThrowPropertyDefinedByEncoder();
         }
 
+        public override byte[] BitmapInfoHeader
+        {
+            get
+            {
+                if (encoder is IVideoEncoderExtraData extraData)
+                {
+                    return extraData.BitmapInfoHeader;
+                }
+                else
+                {
+                    return BaseStream.BitmapInfoHeader;
+                }
+            }
+            set => ThrowPropertyDefinedByEncoder();
+        }
+
         /// <summary>Encodes and writes a frame.</summary>
         public override void WriteFrame(bool isKeyFrame, byte[] frameData, int startIndex, int length)
         {
@@ -94,6 +110,10 @@ namespace SharpAvi.Output
             // Set properties of the base stream
             BaseStream.Codec = encoder.Codec;
             BaseStream.BitsPerPixel = encoder.BitsPerPixel;
+            if (encoder is IVideoEncoderExtraData extraData)
+            {
+                BaseStream.BitmapInfoHeader = extraData.BitmapInfoHeader;
+            }
 
             base.PrepareForWriting();
         }

--- a/SharpAvi/Output/IAviVideoStreamInternal.cs
+++ b/SharpAvi/Output/IAviVideoStreamInternal.cs
@@ -2,5 +2,6 @@
 {
     internal interface IAviVideoStreamInternal : IAviVideoStream, IAviStreamInternal
     {
+        byte[] BitmapInfoHeader { get; set; }
     }
 }

--- a/SharpAvi/Output/VideoStreamWrapperBase.cs
+++ b/SharpAvi/Output/VideoStreamWrapperBase.cs
@@ -47,6 +47,12 @@ namespace SharpAvi.Output
             set { BaseStream.Codec = value; }
         }
 
+        public virtual byte[] BitmapInfoHeader
+        {
+            get { return BaseStream.BitmapInfoHeader; }
+            set { BaseStream.BitmapInfoHeader = value; }
+        }
+
         public virtual void WriteFrame(bool isKeyFrame, byte[] frameData, int startIndex, int length)
         {
             Argument.IsNotNull(frameData, nameof(frameData));


### PR DESCRIPTION
Sorry, I use machine translation.

Some codecs (e.g., Ut Video Codec, AMV4) add extra data after the `BITMAPINFOHEADER` obtained with the `ICCompressGetFormat` macro, and if this is not written to the AVI file, it will result in a broken file.
However, AviWriter is currently generating the `BITMAPINFOHEADER` that it writes internally, which is different from the one obtained with the `ICCompressGetFormat` macro, so it cannot generate the correct AVI when using these codecs.
Therefore, changes have been made to allow writing `BITMAPINFOHEADER` with extra data attached.
To maintain compatibility, I have added a new interface instead of adding properties to IVideoEncoder.

see: ffmpeg extracting BITMAPINFOHEADER extradata code
https://github.com/FFmpeg/FFmpeg/blob/a2564264116aabc5a95755ca93a31508ef547f40/libavformat/avidec.c#L785